### PR TITLE
파이프 라인 Tcp Client 추가

### DIFF
--- a/docs/tcp-pipe-client.puml
+++ b/docs/tcp-pipe-client.puml
@@ -1,0 +1,72 @@
+@startuml
+
+package tcp {
+    interface TcpClient {
+        ' create Socket before writing
+        + write(message: byte[]): void
+        ' dispose Socket after reading
+        + read(): byte[]
+    }
+
+    class DisposableTcpClient implements TcpClient {
+    }
+
+    ' Parsing & Formatting: Visitor Pattern
+    interface Parceable <<visitable>> {
+        + accept(parser: Parser): void
+    }
+
+    interface Formattable <<visitable>> {
+        + accept(formatter: Formatter): void
+    }
+
+    interface Parser <<visitor>> {
+        + parse(parseable: Packet): void
+    }
+
+    class PipeByteParser implements Parser {
+    }
+
+    interface Formatter <<visitor>> {
+        + format(formattable: Packet): void
+    }
+
+    class PipeByteFormatter implements Formatter {
+    }
+
+    ' Tcp Message: Composite Pattern
+    interface TcpMessage <<component>> {
+        + getName(): String
+        + setName(name: String): void
+        + getPoiner(): int
+        + getValue(): String
+        + setValue(value: String)
+    }
+
+    class Packet <<composite>> implements Parceable, Formattable, TcpMessage {
+        - messageComponents: List<TcpMessage>
+        - tcpMessage: byte[]
+    }
+
+    class Item <<leaf>> implements TcpMessage {}
+
+    interface TcpMessageTemplateFactory {
+        + create(tcpMessage: byte[]): List<TcpMessage>
+        + createResponse(Map<String, String> response): TcpMessage
+    }
+
+    class PipeByteTcpMessageTemplateFactory implements TcpMessageTemplateFactory {
+    }
+
+    class PipeByteResponseTcpMessageTemplateFactory implements TcpMessageTemplateFactory {
+    }
+
+    Packet o-down-> TcpMessage
+    Parceable -down-> Parser
+    Formattable -down-> Formatter
+    Parser -down-> Packet
+    PipeByteParser -right-> TcpMessageTemplateFactory
+
+    Formatter -down-> Packet
+}
+@enduml

--- a/docs/tcp-pipe-server.puml
+++ b/docs/tcp-pipe-server.puml
@@ -1,0 +1,39 @@
+@startuml
+
+abstract class TcpServer {
+  - port: int
+  - executor: ExecutorService
+  - serverSocketHolder: AtomicReference<ServerSocket>
+  - socketHolder: AtomicReference<List<Socket>>
+  + start(): void
+  + stop(): void
+}
+
+class EchoServer implements TcpServer{
+  + start(): void
+}
+
+class PipeTcpServer implements TcpServer{
+  - charset: Charset
+  - formatter: Formatter
+  - parser: Parser
+  - parseRequestPacket: void
+  - makeResponsePacket: void
+  + start(): void
+}
+
+interface TcpMessageTemplateFactory{
+  + create(tcpMessage: byte[]): List<TcpMessage>
+  + createResponse(Map<String, String> response): TcpMessage
+}
+
+class TcpServerProperties {
+  - port: int
+  - maxConnection: int
+}
+
+PipeTcpServer -left-> TcpMessageTemplateFactory
+EchoServer -down-> TcpServerProperties
+PipeTcpServer -down-> TcpServerProperties
+
+@enduml

--- a/src/main/java/dev/appkr/demo/Application.java
+++ b/src/main/java/dev/appkr/demo/Application.java
@@ -3,6 +3,7 @@ package dev.appkr.demo;
 import dev.appkr.demo.tcp.config.TcpClientProperties;
 import dev.appkr.demo.tcp.server.EchoServer;
 import dev.appkr.demo.tcp.config.TcpServerProperties;
+import dev.appkr.demo.tcp.server.PipeTcpServer;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -13,10 +14,10 @@ import org.springframework.context.event.EventListener;
 @EnableConfigurationProperties({TcpServerProperties.class, TcpClientProperties.class})
 public class Application {
 
-	final EchoServer echoServer;
+	final PipeTcpServer pipeTcpServer;
 
-	public Application(EchoServer echoServer) {
-		this.echoServer = echoServer;
+	public Application(PipeTcpServer pipeTcpServer) {
+		this.pipeTcpServer = pipeTcpServer;
 	}
 
 	public static void main(String[] args) {
@@ -25,6 +26,6 @@ public class Application {
 
 	@EventListener
 	void onApplicationReadyEvent(ApplicationReadyEvent e) {
-		echoServer.start();
+		pipeTcpServer.start();
 	}
 }

--- a/src/main/java/dev/appkr/demo/Application.java
+++ b/src/main/java/dev/appkr/demo/Application.java
@@ -4,6 +4,7 @@ import dev.appkr.demo.tcp.config.TcpClientProperties;
 import dev.appkr.demo.tcp.server.EchoServer;
 import dev.appkr.demo.tcp.config.TcpServerProperties;
 import dev.appkr.demo.tcp.server.PipeTcpServer;
+import dev.appkr.demo.tcp.server.TcpServer;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -14,9 +15,9 @@ import org.springframework.context.event.EventListener;
 @EnableConfigurationProperties({TcpServerProperties.class, TcpClientProperties.class})
 public class Application {
 
-	final PipeTcpServer pipeTcpServer;
+	final TcpServer pipeTcpServer;
 
-	public Application(PipeTcpServer pipeTcpServer) {
+	public Application(TcpServer pipeTcpServer) {
 		this.pipeTcpServer = pipeTcpServer;
 	}
 

--- a/src/main/java/dev/appkr/demo/commons/exception/InvalidPhoneNumberException.java
+++ b/src/main/java/dev/appkr/demo/commons/exception/InvalidPhoneNumberException.java
@@ -1,0 +1,5 @@
+package dev.appkr.demo.commons.exception;
+
+public class InvalidPhoneNumberException extends RuntimeException {
+
+}

--- a/src/main/java/dev/appkr/demo/tcp/TcpMessageTemplateFactory.java
+++ b/src/main/java/dev/appkr/demo/tcp/TcpMessageTemplateFactory.java
@@ -1,9 +1,10 @@
 package dev.appkr.demo.tcp;
 
+import java.nio.charset.Charset;
 import java.util.List;
 
 public interface TcpMessageTemplateFactory {
 
   // tcpMessage 길이를 분석하여, 하위 Packet의 반복 횟수를 구하여 객체를 생성한다
-  List<TcpMessage> create(byte[] tcpMessage);
+  List<TcpMessage> create(byte[] tcpMessage, Charset charset);
 }

--- a/src/main/java/dev/appkr/demo/tcp/TcpMessageTemplateFactory.java
+++ b/src/main/java/dev/appkr/demo/tcp/TcpMessageTemplateFactory.java
@@ -2,9 +2,13 @@ package dev.appkr.demo.tcp;
 
 import java.nio.charset.Charset;
 import java.util.List;
+import java.util.Map;
 
 public interface TcpMessageTemplateFactory {
 
   // tcpMessage 길이를 분석하여, 하위 Packet의 반복 횟수를 구하여 객체를 생성한다
   List<TcpMessage> create(byte[] tcpMessage, Charset charset);
+
+  // tcpMessage의 response를 생성합니다.
+  TcpMessage createResponse(Map<String, String> response);
 }

--- a/src/main/java/dev/appkr/demo/tcp/server/EchoServer.java
+++ b/src/main/java/dev/appkr/demo/tcp/server/EchoServer.java
@@ -21,19 +21,12 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
-public class EchoServer {
-
-  final int port;
-  final ExecutorService executor;
-
-  final AtomicReference<ServerSocket> serverSocketHolder = new AtomicReference<>();
-  final AtomicReference<List<Socket>> socketHolder = new AtomicReference<>(new ArrayList<>());
-
+public class EchoServer extends TcpServer{
   public EchoServer(TcpServerProperties properties) {
-    this.port = properties.getPort();
-    this.executor = Executors.newFixedThreadPool(properties.getMaxConnection());
+    super(properties.getPort(), Executors.newFixedThreadPool(properties.getMaxConnection()));
   }
 
+  @Override
   @SneakyThrows
   public void start() {
     final ServerSocket serverSocket = new ServerSocket(port);
@@ -69,26 +62,5 @@ public class EchoServer {
         }
       }, executor);
     }
-  }
-
-  @PreDestroy
-  @SneakyThrows
-  public void stop() {
-    if (socketHolder != null) {
-      socketHolder.get().forEach(s -> {
-        try {
-          s.close();
-        } catch (IOException e) {
-          log.error(String.format("Connection to port %s was not closed", s.getPort()));
-        }
-      });
-    }
-
-    if (serverSocketHolder != null && serverSocketHolder.get() != null) {
-      serverSocketHolder.get().close();
-    }
-
-    executor.awaitTermination(5, TimeUnit.SECONDS);
-    executor.shutdown();
   }
 }

--- a/src/main/java/dev/appkr/demo/tcp/server/PipeTcpServer.java
+++ b/src/main/java/dev/appkr/demo/tcp/server/PipeTcpServer.java
@@ -1,0 +1,114 @@
+package dev.appkr.demo.tcp.server;
+
+import dev.appkr.demo.tcp.Item;
+import dev.appkr.demo.tcp.Packet;
+import dev.appkr.demo.tcp.config.TcpServerProperties;
+import dev.appkr.demo.tcp.visitor.Formatter;
+import dev.appkr.demo.tcp.visitor.Parser;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.PreDestroy;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class PipeTcpServer {
+  final int port;
+  final ExecutorService executor;
+  final Charset charset;
+
+  final AtomicReference<ServerSocket> serverSocketHolder = new AtomicReference<>();
+  final AtomicReference<List<Socket>> socketHolder = new AtomicReference<>(new ArrayList<>());
+
+  final Formatter formatter;
+
+  public PipeTcpServer(TcpServerProperties properties, Formatter formatter) {
+    this.port = properties.getPort();
+    this.executor = Executors.newFixedThreadPool(properties.getMaxConnection());
+    this.charset = StandardCharsets.UTF_8;
+    this.formatter = formatter;
+  }
+
+  @SneakyThrows
+  public void start() {
+    final ServerSocket serverSocket = new ServerSocket(port);
+    this.serverSocketHolder.set(serverSocket);
+    log.info("Tcp server is listening at port {}", port);
+
+    while (true) {
+      final Socket socket = serverSocket.accept(); // 여기서 블록킹하고 있다가, 클라이언트가 접속하면 해제됨
+      socketHolder.get().add(socket);
+      log.info("A connection established to port {}", socket.getPort());
+
+      CompletableFuture.runAsync(() -> {
+        PrintWriter writer = null;
+        BufferedReader reader = null;
+        try {
+          writer = new PrintWriter(socket.getOutputStream(), true);
+          reader = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+
+          while ((reader.readLine()) != null) {
+            Packet packet = makeResponsePacket(UUID.randomUUID(), "SUCCESS");
+            packet.accept(formatter);
+            String message = new String(packet.getTcpMessage(), charset);
+            writer.println(message);
+          }
+        } catch (IOException e) {
+          log.warn("{}: {}", e.getMessage(), socket.getPort());
+        } finally {
+          try {
+            reader.close();
+            writer.close();
+            socket.close();
+          } catch (IOException e) {
+            log.error(String.format("Connection to port %s was not closed", socket.getPort()));
+          }
+        }
+      }, executor);
+    }
+  }
+
+  private Packet makeResponsePacket(UUID uuid, String result) {
+    final Packet rootPacket = new Packet("root");
+    rootPacket.add(Item.of("orderId", 1, uuid.toString()));
+    rootPacket.add(Item.of("result", 2, "result"));
+    return rootPacket;
+  }
+
+  @PreDestroy
+  @SneakyThrows
+  public void stop() {
+    if (socketHolder != null) {
+      socketHolder.get().forEach(s -> {
+        try {
+          s.close();
+        } catch (IOException e) {
+          log.error(String.format("Connection to port %s was not closed", s.getPort()));
+        }
+      });
+    }
+
+    if (serverSocketHolder != null && serverSocketHolder.get() != null) {
+      serverSocketHolder.get().close();
+    }
+
+    executor.awaitTermination(5, TimeUnit.SECONDS);
+    executor.shutdown();
+  }
+}

--- a/src/main/java/dev/appkr/demo/tcp/server/TcpServer.java
+++ b/src/main/java/dev/appkr/demo/tcp/server/TcpServer.java
@@ -1,0 +1,50 @@
+package dev.appkr.demo.tcp.server;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.PreDestroy;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public abstract class TcpServer {
+
+  final int port;
+  final ExecutorService executor;
+  final AtomicReference<ServerSocket> serverSocketHolder = new AtomicReference<>();
+  final AtomicReference<List<Socket>> socketHolder = new AtomicReference<>(new ArrayList<>());
+
+  public TcpServer(int port, ExecutorService executor) {
+    this.port = port;
+    this.executor = executor;
+  }
+
+  public abstract void start();
+
+  @PreDestroy
+  @SneakyThrows
+  public void stop() {
+    if (socketHolder != null) {
+      socketHolder.get().forEach(s -> {
+        try {
+          s.close();
+        } catch (IOException e) {
+          log.error(String.format("Connection to port %s was not closed", s.getPort()));
+        }
+      });
+    }
+
+    if (serverSocketHolder != null && serverSocketHolder.get() != null) {
+      serverSocketHolder.get().close();
+    }
+
+    executor.awaitTermination(5, TimeUnit.SECONDS);
+    executor.shutdown();
+  }
+}

--- a/src/main/java/dev/appkr/demo/tcp/service/ValidateRequestPacketService.java
+++ b/src/main/java/dev/appkr/demo/tcp/service/ValidateRequestPacketService.java
@@ -1,0 +1,25 @@
+package dev.appkr.demo.tcp.service;
+
+import dev.appkr.demo.commons.exception.InvalidPhoneNumberException;
+import dev.appkr.demo.tcp.Packet;
+import java.util.regex.Pattern;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ValidateRequestPacketService {
+
+  private static final Pattern phoneNumberPattern = Pattern.compile(
+      "^(01\\d{1}|02|0505|0502|0506|0\\d{1,2})-?(\\d{3,4})-?(\\d{4})");
+
+  public void validRequestPacket(Packet request) {
+    request.getMessageComponents().forEach(
+        mc -> {
+          if (mc.getName().contains("Phone")) {
+            if (!phoneNumberPattern.matcher(mc.getValue()).matches()) {
+              throw new InvalidPhoneNumberException();
+            }
+          }
+        }
+    );
+  }
+}

--- a/src/main/java/dev/appkr/demo/tcp/tcpExample/FixedByteParser.java
+++ b/src/main/java/dev/appkr/demo/tcp/tcpExample/FixedByteParser.java
@@ -25,7 +25,7 @@ public class FixedByteParser implements Parser {
   @Override
   public void parse(Packet parseable) {
     final byte[] src = parseable.getTcpMessage();
-    final List<TcpMessage> components = templateFactory.create(src);
+    final List<TcpMessage> components = templateFactory.create(src, charset);
     parseable.setMessageComponents(components);
 
     doParse(src, components, new AtomicInteger(0));

--- a/src/main/java/dev/appkr/demo/tcp/tcpExample/PipeByteFormatter.java
+++ b/src/main/java/dev/appkr/demo/tcp/tcpExample/PipeByteFormatter.java
@@ -1,0 +1,44 @@
+package dev.appkr.demo.tcp.tcpExample;
+
+import dev.appkr.demo.tcp.Item;
+import dev.appkr.demo.tcp.Packet;
+import dev.appkr.demo.tcp.TcpMessage;
+import dev.appkr.demo.tcp.visitor.Formatter;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import lombok.Setter;
+
+public class PipeByteFormatter implements Formatter {
+
+  @Setter
+  private Charset charset = StandardCharsets.UTF_8;
+
+  @Override
+  public void format(Packet packet) {
+    String tcpMessage = doFormat(packet.getMessageComponents()) + "\n";
+    packet.setTcpMessage(tcpMessage.getBytes(charset));
+  }
+
+  private String doFormat(List<TcpMessage> components) {
+    StringBuilder sb = new StringBuilder();
+    components.forEach(
+        component -> {
+          String formattedMessage;
+          if (component instanceof Item) {
+            formattedMessage = formatFor(component);
+          } else {
+            formattedMessage = doFormat(((Packet) component).getMessageComponents());
+          }
+
+          sb.append(formattedMessage);
+        }
+    );
+
+    return sb.toString();
+  }
+
+  private String formatFor(TcpMessage tcpMessage) {
+    return tcpMessage.getValue() + "|";
+  }
+}

--- a/src/main/java/dev/appkr/demo/tcp/tcpExample/PipeByteFormatter.java
+++ b/src/main/java/dev/appkr/demo/tcp/tcpExample/PipeByteFormatter.java
@@ -8,7 +8,9 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import lombok.Setter;
+import org.springframework.stereotype.Component;
 
+@Component
 public class PipeByteFormatter implements Formatter {
 
   @Setter

--- a/src/main/java/dev/appkr/demo/tcp/tcpExample/PipeByteParser.java
+++ b/src/main/java/dev/appkr/demo/tcp/tcpExample/PipeByteParser.java
@@ -9,7 +9,9 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import lombok.Setter;
+import org.springframework.stereotype.Component;
 
+@Component
 public class PipeByteParser implements Parser {
 
   @Setter

--- a/src/main/java/dev/appkr/demo/tcp/tcpExample/PipeByteParser.java
+++ b/src/main/java/dev/appkr/demo/tcp/tcpExample/PipeByteParser.java
@@ -1,0 +1,50 @@
+package dev.appkr.demo.tcp.tcpExample;
+
+import dev.appkr.demo.tcp.Item;
+import dev.appkr.demo.tcp.Packet;
+import dev.appkr.demo.tcp.TcpMessage;
+import dev.appkr.demo.tcp.TcpMessageTemplateFactory;
+import dev.appkr.demo.tcp.visitor.Parser;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import lombok.Setter;
+
+public class PipeByteParser implements Parser {
+
+  @Setter
+  private Charset charset = StandardCharsets.UTF_8;
+
+  private final TcpMessageTemplateFactory templateFactory;
+
+  public PipeByteParser(TcpMessageTemplateFactory templateFactory) {
+    this.templateFactory = templateFactory;
+  }
+
+
+  @Override
+  public void parse(Packet parseable) {
+    final byte[] src = parseable.getTcpMessage();
+    final List<TcpMessage> components = templateFactory.create(src, charset);
+    parseable.setMessageComponents(components);
+
+    doParse(new String(src, charset), components);
+  }
+
+  private void doParse(String message, List<TcpMessage> components) {
+    String[] split = message.split("\\|");
+    components.stream()
+        .forEach(component -> {
+
+          if (component instanceof Item) {
+            final String value = split[component.getPointer() - 1];
+            component.setValue(value);
+          } else {
+            final String subPacketName = String.valueOf(component.getName());
+            component.setName(subPacketName);
+            ((Packet) component).setTcpMessage(message.getBytes(charset));
+            doParse(message, ((Packet) component).getMessageComponents());
+          }
+        });
+  }
+}

--- a/src/main/java/dev/appkr/demo/tcp/tcpExample/PipeByteResponseTcpMessageTemplateFactory.java
+++ b/src/main/java/dev/appkr/demo/tcp/tcpExample/PipeByteResponseTcpMessageTemplateFactory.java
@@ -7,6 +7,7 @@ import dev.appkr.demo.tcp.TcpMessageTemplateFactory;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class PipeByteResponseTcpMessageTemplateFactory implements TcpMessageTemplateFactory {
   @Override
@@ -18,8 +19,13 @@ public class PipeByteResponseTcpMessageTemplateFactory implements TcpMessageTemp
     return components;
   }
 
-  public int getNoPipeline(byte[] tcpMessage, Charset charset) {
-    String message = new String(tcpMessage, charset);
-    return message.length() - message.replace("|", "").length();
+  @Override
+  public TcpMessage createResponse(Map<String, String> response) {
+    final Packet rootPacket = new Packet("root");
+    int i = 1;
+    for (String key : response.keySet()) {
+      rootPacket.add(Item.of(key, i++, response.get(key)));
+    }
+    return rootPacket;
   }
 }

--- a/src/main/java/dev/appkr/demo/tcp/tcpExample/PipeByteResponseTcpMessageTemplateFactory.java
+++ b/src/main/java/dev/appkr/demo/tcp/tcpExample/PipeByteResponseTcpMessageTemplateFactory.java
@@ -1,0 +1,25 @@
+package dev.appkr.demo.tcp.tcpExample;
+
+import dev.appkr.demo.tcp.Item;
+import dev.appkr.demo.tcp.Packet;
+import dev.appkr.demo.tcp.TcpMessage;
+import dev.appkr.demo.tcp.TcpMessageTemplateFactory;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PipeByteResponseTcpMessageTemplateFactory implements TcpMessageTemplateFactory {
+  @Override
+  public List<TcpMessage> create(byte[] tcpMessage, Charset charset) {
+    final List<TcpMessage> components = new ArrayList<>();
+    components.add(Item.of("orderId", 1));
+    components.add(Item.of("result", 2));
+
+    return components;
+  }
+
+  public int getNoPipeline(byte[] tcpMessage, Charset charset) {
+    String message = new String(tcpMessage, charset);
+    return message.length() - message.replace("|", "").length();
+  }
+}

--- a/src/main/java/dev/appkr/demo/tcp/tcpExample/PipeByteTcpMessageTemplateFactory.java
+++ b/src/main/java/dev/appkr/demo/tcp/tcpExample/PipeByteTcpMessageTemplateFactory.java
@@ -1,0 +1,38 @@
+package dev.appkr.demo.tcp.tcpExample;
+
+import dev.appkr.demo.tcp.Item;
+import dev.appkr.demo.tcp.Packet;
+import dev.appkr.demo.tcp.TcpMessage;
+import dev.appkr.demo.tcp.TcpMessageTemplateFactory;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PipeByteTcpMessageTemplateFactory implements TcpMessageTemplateFactory {
+  @Override
+  public List<TcpMessage> create(byte[] tcpMessage, Charset charset) {
+    final List<TcpMessage> components = new ArrayList<>();
+    components.add(Item.of("ordererName", 1));
+    components.add(Item.of("ordererPhone", 2));
+    components.add(Item.of("receiverName", 3));
+    components.add(Item.of("receiverPhone", 4));
+    components.add(Item.of("receiverAddress", 5));
+
+    final int noOfSubPacket = (getNoPipeline(tcpMessage, charset) - 5) / 4;
+    Packet subPacket = new Packet("products");
+    for (int i = 0; i < noOfSubPacket; i++) {
+      subPacket.add(Item.of("productCode", 6 + (i * 4)));
+      subPacket.add(Item.of("productName", 7 + (i * 4)));
+      subPacket.add(Item.of("unitPrice", 8 + (i * 4)));
+      subPacket.add(Item.of("quantity", 9 + (i * 4)));
+    }
+    components.add(subPacket);
+
+    return components;
+  }
+
+  public int getNoPipeline(byte[] tcpMessage, Charset charset) {
+    String message = new String(tcpMessage, charset);
+    return message.length() - message.replace("|", "").length();
+  }
+}

--- a/src/main/java/dev/appkr/demo/tcp/tcpExample/PipeByteTcpMessageTemplateFactory.java
+++ b/src/main/java/dev/appkr/demo/tcp/tcpExample/PipeByteTcpMessageTemplateFactory.java
@@ -7,7 +7,9 @@ import dev.appkr.demo.tcp.TcpMessageTemplateFactory;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
+import org.springframework.stereotype.Component;
 
+@Component
 public class PipeByteTcpMessageTemplateFactory implements TcpMessageTemplateFactory {
   @Override
   public List<TcpMessage> create(byte[] tcpMessage, Charset charset) {

--- a/src/main/java/dev/appkr/demo/tcp/tcpExample/PipeByteTcpMessageTemplateFactory.java
+++ b/src/main/java/dev/appkr/demo/tcp/tcpExample/PipeByteTcpMessageTemplateFactory.java
@@ -7,6 +7,7 @@ import dev.appkr.demo.tcp.TcpMessageTemplateFactory;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -31,6 +32,11 @@ public class PipeByteTcpMessageTemplateFactory implements TcpMessageTemplateFact
     components.add(subPacket);
 
     return components;
+  }
+
+  @Override
+  public TcpMessage createResponse(Map<String, String> response) {
+    return null;
   }
 
   public int getNoPipeline(byte[] tcpMessage, Charset charset) {

--- a/src/test/java/dev/appkr/demo/tcp/client/TcpClientPipeMessageTest.java
+++ b/src/test/java/dev/appkr/demo/tcp/client/TcpClientPipeMessageTest.java
@@ -1,0 +1,61 @@
+package dev.appkr.demo.tcp.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import dev.appkr.demo.tcp.Item;
+import dev.appkr.demo.tcp.Packet;
+import dev.appkr.demo.tcp.config.TcpClientProperties;
+import dev.appkr.demo.tcp.tcpExample.PipeByteFormatter;
+import dev.appkr.demo.tcp.tcpExample.PipeByteParser;
+import dev.appkr.demo.tcp.tcpExample.PipeByteResponseTcpMessageTemplateFactory;
+import dev.appkr.demo.tcp.tcpExample.PipeByteTcpMessageTemplateFactory;
+import dev.appkr.demo.tcp.visitor.Formatter;
+import dev.appkr.demo.tcp.visitor.Parser;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+
+@Slf4j
+public class TcpClientPipeMessageTest {
+
+  final TcpClientProperties properties = new TcpClientProperties();
+  final Formatter formatter = new PipeByteFormatter();
+  final Parser parser = new PipeByteParser(new PipeByteResponseTcpMessageTemplateFactory());
+
+  @Test
+  void disposableTcpClient() throws Exception {
+    final TcpClient client = new DisposableTcpClient(properties.getHost(), properties.getPort(),
+        properties.getCharset());
+
+    Packet packet = createPacket();
+    packet.accept(formatter);
+    client.write(packet.getTcpMessage());
+    Packet response = new Packet("root", client.read());
+    response.accept(parser);
+
+    log.info("{}", response.toMap());
+  }
+
+  private Packet createPacket() {
+    final Packet rootPacket = new Packet("root");
+    rootPacket.add(Item.of("ordererName", 1, "김메쉬"));
+    rootPacket.add(Item.of("ordererPhone", 2, "010-1234-5678"));
+    rootPacket.add(Item.of("receiverName", 3, "홍길동"));
+    rootPacket.add(Item.of("receiverPhone", 4, "010-4321-8765"));
+    rootPacket.add(Item.of("receiverAddress", 5, "서울특별시 강남구 대치동 890-12 다봉타워 13층"));
+
+    Packet subPacket = new Packet("products");
+    subPacket.add(Item.of("productCode", 6, "68d8a5d5-2860-4a0c-bf64-3c879cf3cf61"));
+    subPacket.add(Item.of("productName", 7, "지포라이터"));
+    subPacket.add(Item.of("unitPrice", 8, "50000"));
+    subPacket.add(Item.of("quantity", 9, "1"));
+
+    subPacket.add(Item.of("productCode", 10, "864bc23c-59eb-4a55-b68e-f3cbc9700315"));
+    subPacket.add(Item.of("productName", 11, "지포라이터 부싯돌 셋트"));
+    subPacket.add(Item.of("unitPrice", 12, "5000"));
+    subPacket.add(Item.of("quantity", 13, "1"));
+    rootPacket.add(subPacket);
+
+    return rootPacket;
+  }
+
+}

--- a/src/test/java/dev/appkr/demo/tcp/client/TcpClientPipeMessageTest.java
+++ b/src/test/java/dev/appkr/demo/tcp/client/TcpClientPipeMessageTest.java
@@ -1,17 +1,15 @@
 package dev.appkr.demo.tcp.client;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import dev.appkr.demo.tcp.Item;
 import dev.appkr.demo.tcp.Packet;
 import dev.appkr.demo.tcp.config.TcpClientProperties;
 import dev.appkr.demo.tcp.tcpExample.PipeByteFormatter;
 import dev.appkr.demo.tcp.tcpExample.PipeByteParser;
 import dev.appkr.demo.tcp.tcpExample.PipeByteResponseTcpMessageTemplateFactory;
-import dev.appkr.demo.tcp.tcpExample.PipeByteTcpMessageTemplateFactory;
 import dev.appkr.demo.tcp.visitor.Formatter;
 import dev.appkr.demo.tcp.visitor.Parser;
 import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 @Slf4j
@@ -26,13 +24,13 @@ public class TcpClientPipeMessageTest {
     final TcpClient client = new DisposableTcpClient(properties.getHost(), properties.getPort(),
         properties.getCharset());
 
-    Packet packet = createPacket();
+    final Packet packet = createPacket();
     packet.accept(formatter);
     client.write(packet.getTcpMessage());
-    Packet response = new Packet("root", client.read());
+    final Packet response = new Packet("root", client.read());
     response.accept(parser);
 
-    log.info("{}", response.toMap());
+    Assertions.assertThat(response.getMessageComponents().get(1).getValue()).isEqualTo("SUCCESS");
   }
 
   private Packet createPacket() {

--- a/src/test/java/dev/appkr/demo/tcp/client/TcpClientPipeMessageTest.java
+++ b/src/test/java/dev/appkr/demo/tcp/client/TcpClientPipeMessageTest.java
@@ -18,12 +18,11 @@ public class TcpClientPipeMessageTest {
   final TcpClientProperties properties = new TcpClientProperties();
   final Formatter formatter = new PipeByteFormatter();
   final Parser parser = new PipeByteParser(new PipeByteResponseTcpMessageTemplateFactory());
+  final TcpClient client = new DisposableTcpClient(properties.getHost(), properties.getPort(),
+      properties.getCharset());
 
   @Test
   void disposableTcpClient() throws Exception {
-    final TcpClient client = new DisposableTcpClient(properties.getHost(), properties.getPort(),
-        properties.getCharset());
-
     final Packet packet = createPacket();
     packet.accept(formatter);
     client.write(packet.getTcpMessage());

--- a/src/test/java/dev/appkr/demo/tcp/tcpExample/FixedByteParserTest.java
+++ b/src/test/java/dev/appkr/demo/tcp/tcpExample/FixedByteParserTest.java
@@ -6,6 +6,7 @@ import dev.appkr.demo.tcp.TcpMessage;
 import dev.appkr.demo.tcp.TcpMessageTemplateFactory;
 import dev.appkr.demo.tcp.config.TcpClientProperties;
 import dev.appkr.demo.tcp.visitor.Parser;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -145,7 +146,7 @@ class FixedByteParserTest {
   static class FixedByteTcpMessageTemplateFactory implements TcpMessageTemplateFactory {
 
     @Override
-    public List<TcpMessage> create(byte[] tcpMessage) {
+    public List<TcpMessage> create(byte[] tcpMessage, Charset charset) {
       final List<TcpMessage> components = new ArrayList<>();
       components.add(Item.of("messageType", 4));
       components.add(Item.of("serviceCode", 2));

--- a/src/test/java/dev/appkr/demo/tcp/tcpExample/FixedByteParserTest.java
+++ b/src/test/java/dev/appkr/demo/tcp/tcpExample/FixedByteParserTest.java
@@ -9,6 +9,7 @@ import dev.appkr.demo.tcp.visitor.Parser;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.IntStream;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
@@ -180,6 +181,11 @@ class FixedByteParserTest {
       components.add(Item.of("delegatedCsContact", 15));
 
       return components;
+    }
+
+    @Override
+    public TcpMessage createResponse(Map<String, String> response) {
+      return null;
     }
 
     public int getNoOfSubPacket(byte[] tcpMessage) {

--- a/src/test/java/dev/appkr/demo/tcp/tcpExample/PipeByteFormatterTest.java
+++ b/src/test/java/dev/appkr/demo/tcp/tcpExample/PipeByteFormatterTest.java
@@ -1,0 +1,56 @@
+package dev.appkr.demo.tcp.tcpExample;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import dev.appkr.demo.tcp.Item;
+import dev.appkr.demo.tcp.Packet;
+import dev.appkr.demo.tcp.config.TcpClientProperties;
+import dev.appkr.demo.tcp.visitor.Formatter;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+
+@Slf4j
+class PipeByteFormatterTest {
+
+  final TcpClientProperties properties = new TcpClientProperties();
+
+  @Test
+  void format() {
+    // given
+    final Packet packet = createPacket();
+    final Formatter formatter = new PipeByteFormatter();
+
+    // when
+    packet.accept(formatter);
+
+    // then
+//    assertEquals(getLength(packet), packet.getTcpMessage().length); // 783
+    log.info("{}", new String(packet.getTcpMessage(), properties.getCharset()));
+    /**
+     * orderName|
+     */
+  }
+
+  private Packet createPacket() {
+    final Packet rootPacket = new Packet("root");
+    rootPacket.add(Item.of("ordererName", 1, "김메쉬"));
+    rootPacket.add(Item.of("ordererPhone", 2, "010-1234-5678"));
+    rootPacket.add(Item.of("receiverName", 3, "홍길동"));
+    rootPacket.add(Item.of("receiverPhone", 4, "010-4321-8765"));
+    rootPacket.add(Item.of("receiverAddress", 5, "서울특별시 강남구 대치동 890-12 다봉타워 13층"));
+
+    Packet subPacket = new Packet("products");
+    subPacket.add(Item.of("productCode", 6, "68d8a5d5-2860-4a0c-bf64-3c879cf3cf61"));
+    subPacket.add(Item.of("productName", 7, "지포라이터"));
+    subPacket.add(Item.of("unitPrice", 8, "50000"));
+    subPacket.add(Item.of("quantity", 9, "1"));
+
+    subPacket.add(Item.of("productCode", 10, "864bc23c-59eb-4a55-b68e-f3cbc9700315"));
+    subPacket.add(Item.of("productName", 11, "지포라이터 부싯돌 셋트"));
+    subPacket.add(Item.of("unitPrice", 12, "5000"));
+    subPacket.add(Item.of("quantity", 13, "1"));
+    rootPacket.add(subPacket);
+
+    return rootPacket;
+  }
+}

--- a/src/test/java/dev/appkr/demo/tcp/tcpExample/PipeByteParserTest.java
+++ b/src/test/java/dev/appkr/demo/tcp/tcpExample/PipeByteParserTest.java
@@ -1,0 +1,66 @@
+package dev.appkr.demo.tcp.tcpExample;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import dev.appkr.demo.tcp.Item;
+import dev.appkr.demo.tcp.Packet;
+import dev.appkr.demo.tcp.TcpMessage;
+import dev.appkr.demo.tcp.TcpMessageTemplateFactory;
+import dev.appkr.demo.tcp.config.TcpClientProperties;
+import dev.appkr.demo.tcp.visitor.Parser;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+
+@Slf4j
+class PipeByteParserTest {
+
+  final TcpClientProperties properties = new TcpClientProperties();
+
+  @Test
+  public void parse() throws Exception {
+    //given
+    final String tcpMessage = "김메쉬|010-1234-5678|홍길동|010-4321-8765|서울특별시 강남구 대치동 890-12 다봉타워 13층|68d8a5d5-2860-4a0c-bf64-3c879cf3cf61|지포라이터|50000|1|864bc23c-59eb-4a55-b68e-f3cbc9700315|지포라이터 부싯돌 셋트|5000|1|";
+
+    //when
+    final Packet packet = new Packet("root", tcpMessage.getBytes(properties.getCharset()));
+    final TcpMessageTemplateFactory templateFactory = new PipeByteTcpMessageTemplateFactory();
+    final Parser parser = new PipeByteParser(templateFactory);
+    packet.accept(parser);
+
+    //then
+    log.info("{}", packet.toMap());
+  }
+
+  static class PipeByteTcpMessageTemplateFactory implements TcpMessageTemplateFactory {
+
+    @Override
+    public List<TcpMessage> create(byte[] tcpMessage, Charset charset) {
+      final List<TcpMessage> components = new ArrayList<>();
+      components.add(Item.of("ordererName", 1));
+      components.add(Item.of("ordererPhone", 2));
+      components.add(Item.of("receiverName", 3));
+      components.add(Item.of("receiverPhone", 4));
+      components.add(Item.of("receiverAddress", 5));
+
+      final int noOfSubPacket = (getNoPipeline(tcpMessage, charset) - 5) / 4;
+      Packet subPacket = new Packet("products");
+      for (int i = 0; i < noOfSubPacket; i++) {
+        subPacket.add(Item.of("productCode", 6 + (i * 4)));
+        subPacket.add(Item.of("productName", 7 + (i * 4)));
+        subPacket.add(Item.of("unitPrice", 8 + (i * 4)));
+        subPacket.add(Item.of("quantity", 9 + (i * 4)));
+      }
+      components.add(subPacket);
+
+      return components;
+    }
+
+    public int getNoPipeline(byte[] tcpMessage, Charset charset) {
+      String message = new String(tcpMessage, charset);
+      return message.length() - message.replace("|", "").length();
+    }
+  }
+}

--- a/src/test/java/dev/appkr/demo/tcp/tcpExample/PipeByteParserTest.java
+++ b/src/test/java/dev/appkr/demo/tcp/tcpExample/PipeByteParserTest.java
@@ -1,16 +1,9 @@
 package dev.appkr.demo.tcp.tcpExample;
 
-import static org.junit.jupiter.api.Assertions.*;
-
-import dev.appkr.demo.tcp.Item;
 import dev.appkr.demo.tcp.Packet;
-import dev.appkr.demo.tcp.TcpMessage;
 import dev.appkr.demo.tcp.TcpMessageTemplateFactory;
 import dev.appkr.demo.tcp.config.TcpClientProperties;
 import dev.appkr.demo.tcp.visitor.Parser;
-import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 
@@ -32,35 +25,5 @@ class PipeByteParserTest {
 
     //then
     log.info("{}", packet.toMap());
-  }
-
-  static class PipeByteTcpMessageTemplateFactory implements TcpMessageTemplateFactory {
-
-    @Override
-    public List<TcpMessage> create(byte[] tcpMessage, Charset charset) {
-      final List<TcpMessage> components = new ArrayList<>();
-      components.add(Item.of("ordererName", 1));
-      components.add(Item.of("ordererPhone", 2));
-      components.add(Item.of("receiverName", 3));
-      components.add(Item.of("receiverPhone", 4));
-      components.add(Item.of("receiverAddress", 5));
-
-      final int noOfSubPacket = (getNoPipeline(tcpMessage, charset) - 5) / 4;
-      Packet subPacket = new Packet("products");
-      for (int i = 0; i < noOfSubPacket; i++) {
-        subPacket.add(Item.of("productCode", 6 + (i * 4)));
-        subPacket.add(Item.of("productName", 7 + (i * 4)));
-        subPacket.add(Item.of("unitPrice", 8 + (i * 4)));
-        subPacket.add(Item.of("quantity", 9 + (i * 4)));
-      }
-      components.add(subPacket);
-
-      return components;
-    }
-
-    public int getNoPipeline(byte[] tcpMessage, Charset charset) {
-      String message = new String(tcpMessage, charset);
-      return message.length() - message.replace("|", "").length();
-    }
   }
 }


### PR DESCRIPTION
## 파이프 라인 Tcp Client 추가
- format 시 value 뒤에 '|' 추가
- parse 시 '|'의 총 개수를 구한 뒤 root packet의 개수를 뺀 뒤, subPacket 개수 구함